### PR TITLE
Fix term "Risiko-Begegnungen"

### DIFF
--- a/resources/i18n/de/strings.xml
+++ b/resources/i18n/de/strings.xml
@@ -146,6 +146,6 @@
   <!-- XTXT: Status Tab Notice - Subtitle Text -->
   <string name="STATUS_TAB_NOTICE_SUBTITLE_TEXT">"Es wird nur noch bis zum 30. April 2023 möglich sein, andere Personen über die Corona-Warn-App zu warnen!"</string>
   <!-- XTXT: Status Tab Notice - Long Text -->
-  <string name="STATUS_TAB_NOTICE_LONG_TEXT">"Ab dem 1. Mai 2023 können Sie andere Personen hinsichtlich eines erhöhten Infektionsrisikos nicht mehr warnen und Sie erhalten keine Warnungen mehr über Risikobegegnungen. Ab dem 1. Juni 2023 wird die Corona-Warn-App nicht mehr weiterentwickelt. Auf Ihre in der App gespeicherten Zertifikate und das Kontakt-Tagebuch haben Sie jedoch weiterhin Zugriff. Allerdings können Sie keine neuen Zertifikate mehr hinzufügen."</string>
+  <string name="STATUS_TAB_NOTICE_LONG_TEXT">"Ab dem 1. Mai 2023 können Sie andere Personen hinsichtlich eines erhöhten Infektionsrisikos nicht mehr warnen und Sie erhalten keine Warnungen mehr über Risiko-Begegnungen. Ab dem 1. Juni 2023 wird die Corona-Warn-App nicht mehr weiterentwickelt. Auf Ihre in der App gespeicherten Zertifikate und das Kontakt-Tagebuch haben Sie jedoch weiterhin Zugriff. Allerdings können Sie keine neuen Zertifikate mehr hinzufügen."</string>
 
 </resources>


### PR DESCRIPTION
This PR fixes the Term "Risiko-Begegnungen", which was incorrectly spelled as "Risikobegegnungen". Merge if you want (: